### PR TITLE
Adapt to API changes in Biotite

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 requires = [
     "setuptools >= 0.30",
     "wheel >= 0.30",
-    "biotite >= 0.28",
+    "biotite >= 0.36",
     "numpy >= 1.14, <= 1.21",
     "msgpack >= 0.5.6",
     "cython >= 0.29"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 requires = [
     "setuptools >= 0.30",
     "wheel >= 0.30",
-    "biotite >= 0.36",
+    "biotite >= 0.35",
     "numpy >= 1.14, <= 1.21",
     "msgpack >= 0.5.6",
     "cython >= 0.29"

--- a/setup.py
+++ b/setup.py
@@ -211,7 +211,7 @@ setup(
 
     entry_points = {"console_scripts": "hydride = hydride.cli:main"},
     
-    install_requires = ["biotite >= 0.28",
+    install_requires = ["biotite >= 0.36",
                         "numpy >= 1.13"],
     python_requires = ">=3.7",
     

--- a/setup.py
+++ b/setup.py
@@ -211,7 +211,7 @@ setup(
 
     entry_points = {"console_scripts": "hydride = hydride.cli:main"},
     
-    install_requires = ["biotite >= 0.36",
+    install_requires = ["biotite >= 0.35",
                         "numpy >= 1.13"],
     python_requires = ">=3.7",
     

--- a/src/hydride/charge.py
+++ b/src/hydride/charge.py
@@ -110,7 +110,7 @@ def estimate_amino_acid_charges(atoms, ph):
     atom_charges = np.zeros(atoms.array_length(), dtype=int)
     
     # Charges for termini
-    amino_acid_mask = struc.filter_amino_acids(atoms)
+    amino_acid_mask = struc.filter_canonical_amino_acids(atoms)
     amino_indices   = np.where((atoms.atom_name ==   "N") & amino_acid_mask)[0]
     carboxy_indices = np.where((atoms.atom_name == "OXT") & amino_acid_mask)[0]
     chain_starts = struc.get_chain_starts(atoms, add_exclusive_stop=True)


### PR DESCRIPTION
Biotite 0.35 changed the function `filter_amino_acids()` to `filter_canonical_amino_acids()`. This PR adapts the function change and set the required Biotite version.