### PR TITLE
Clarifiy note about protonation estimation

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -281,7 +281,7 @@ Both :func:`add_hydrogen()` and :func:`relax_hydrogen()` require associated
 formal charges for correct fragment identification or the electrostatic
 potential, respectively.
 However, for many entries in the *RCSB PDB* they are not properly set.
-At least for amino acids this issue can be remedied with
+At least for canonical amino acids this issue can be remedied with
 :func:`estimate_amino_acid_charges()`.
 This function calculates the formal charges of atoms in amino acids based on a
 given pH value.

--- a/doc/cli.rst
+++ b/doc/cli.rst
@@ -55,7 +55,7 @@ heavy atom, this can lead to e.g. protonated carboxy groups or deprotonated
 amino groups.
 *Hydride* recalculates the formal charges of atoms in amino acids, if the
 ``--charges``/``-c`` parameter together with the desired pH value is given.
-Note that only formal charges in amino acids are updated this way.
+Note that only formal charges in canonical amino acids are updated this way.
 For all other molecules the formal charge values from the input structure file
 is taken.
 Furthermore, the underlying method assigns charges based on the pK values of

--- a/src/hydride/charge.py
+++ b/src/hydride/charge.py
@@ -87,6 +87,10 @@ def estimate_amino_acid_charges(atoms, ph):
         The estimated charges.
         0 for all atoms that are not part of an amino acid.
     
+    Notes
+    -----
+    The protonation state is only estimated for canonical amino acids.
+    
     References
     ----------
     

--- a/src/hydride/cli.py
+++ b/src/hydride/cli.py
@@ -124,8 +124,8 @@ def main(args=None):
     )
     parser.add_argument(
         "--charges", "-c", type=float, metavar="PH",
-        help="Recalculate the charges of atoms in amino acids based on the "
-             "given pH value. "
+        help="Recalculate the charges of atoms in canonical amino acids based "
+             "on the given pH value. "
              "This estimation does not take the surrounding amino acids into "
              "account."
     )


### PR DESCRIPTION
As discussed in #6 , this PR adds a note in the documentation, that charge estimation only works for canonical amino acids, as opposed to amino acids in general.