### PR TITLE
Read bonds from CIF/BCIF file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 test = [
-  "pytest",
+    "pytest",
 ]
 lint = [
     "ruff==0.5.2",


### PR DESCRIPTION
Currently the CLI does infer bonds from a CIF/BCIF file, due to a remnant from the time bonds could not be parsed from PDBx. This leads to bugs with heteroresidues such as #14. This PR fixes this.

Fixes #14.