### PR TITLE
Fix setup for CCD components with missing coordinates

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -59,11 +59,11 @@ jobs:
           platforms: all
 
       - name: Build & (optionally) test wheels
-        uses: pypa/cibuildwheel@v2.19.1
+        uses: pypa/cibuildwheel@v3.2.0
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: dist
+          name: release-${{ matrix.os }}
           path: ./wheelhouse/*.whl
           if-no-files-found: error
 
@@ -78,9 +78,9 @@ jobs:
         submodules: true
     - name: Build source distribution
       run: pipx run build --sdist
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
-        name: dist
+        name: release-sdist
         path: dist/*.tar.gz
         if-no-files-found: error
 
@@ -106,7 +106,7 @@ jobs:
         run: sphinx-build ./doc ./build/doc
       - name: Zipping documentation
         run: cd .//build; zip -r doc.zip doc; cd ..
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: doc
           path: build//doc.zip
@@ -124,7 +124,15 @@ jobs:
       - make-doc
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
+      with:
+        pattern: release-*
+        merge-multiple: true
+        path: dist
+    - uses: actions/download-artifact@v4
+      with:
+        name: doc
+        path: doc
     - name: List distributions to be uploaded
       run: ls dist
     - name: Upload to GitHub Releases

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -11,7 +11,7 @@ on:
     - published
 
 env:
-  CIBW_BUILD: cp310-* cp311-* cp312-*
+  CIBW_BUILD: cp311-* cp312-* cp313-*
   CIBW_ARCHS_LINUX: "x86_64"
   CIBW_ARCHS_MACOS: "x86_64 arm64"
   CIBW_ARCHS_WINDOWS: "x86 AMD64"

--- a/setup.py
+++ b/setup.py
@@ -148,7 +148,8 @@ if not isfile(fragment_file_path):
                 print(f"Compiling fragment library... ({i}/{len(mol_names)})", end="\r")
             try:
                 mol = info.residue(mol_name)
-            except KeyError:
+            except ValueError:
+                # Molecule has missing coordinates
                 continue
             std_fragment_library.add_molecule(mol)
     print("Compiling fragment library... Done" + " " * 20)


### PR DESCRIPTION
Fixes the error `Missing coordinates for some atoms` when building/installing `hydride`